### PR TITLE
prevent IV collisions for awskms

### DIFF
--- a/providers/awskms/kms.go
+++ b/providers/awskms/kms.go
@@ -7,6 +7,7 @@ import (
 	"crypto/cipher"
 	"encoding/binary"
 	"io"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -31,6 +32,9 @@ type KMSCrypter struct {
 
 	// encryptedKeyLength is the length of the DEK.
 	encryptedKeyLength uint8
+
+	// encryptedKeyEncryptionCount is the number of encryptions performed with the current key
+	encryptedKeyEncryptionCount atomic.Uint64
 
 	// cipherBlock is the 256-bit AES GCM block cipher.
 	aesgcm cipher.AEAD
@@ -108,10 +112,8 @@ func (k *KMSCrypter) Encrypt(w io.Writer, r io.Reader) error {
 		return errors.Wrap(err, "failed to read from io.Reader")
 	}
 
-	nonce, err := sqlcrypter.GenerateBytes(k.aesgcm.NonceSize())
-	if err != nil {
-		return errors.Wrap(err, "failed to generate 12-byte random nonce")
-	}
+	nonce := make([]byte, 12)
+	binary.LittleEndian.PutUint64(nonce[4:], k.encryptedKeyEncryptionCount.Add(1))
 
 	ciphertext := k.aesgcm.Seal(nil, nonce, src.Bytes(), nil)
 


### PR DESCRIPTION
This PR partially fixes #127. It prevents the possibility of an IV collision when using the `awskms` provider. The `aesgcm` provider remains vulnerable.

This change switches from a random IV to a counter-based IV in a backward-compatible way for the `awskms` provider in order to mitigate the risk of an IV collision.