### PR TITLE
Fixed nil crypter initialization can panic

### DIFF
--- a/crypter.go
+++ b/crypter.go
@@ -30,11 +30,19 @@ func Init(c Crypterer) {
 // Encrypt reads plaintext from an io.Reader
 // and writes ciphertext to an io.Writer.
 func Encrypt(w io.Writer, r io.Reader) error {
+	if crypter == nil {
+		return ErrCrypterNotInitialized
+	}
+
 	return crypter.Encrypt(w, r)
 }
 
 // Decrypt reads ciphertext from an io.Reader
 // and writes plaintext to an io.Writer.
 func Decrypt(w io.Writer, r io.Reader) error {
+	if crypter == nil {
+		return ErrCrypterNotInitialized
+	}
+
 	return crypter.Decrypt(w, r)
 }

--- a/crypter_test.go
+++ b/crypter_test.go
@@ -78,6 +78,22 @@ func Test_Encrypt(t *testing.T) {
 	assert.Equal(t, ciphertext, writer.String())
 }
 
+func Test_Encrypt_NotInitialized(t *testing.T) {
+	prev := crypter
+	t.Cleanup(func() {
+		crypter = prev
+	})
+
+	crypter = nil
+
+	reader := bytes.NewBufferString("Hello World")
+	writer := new(bytes.Buffer)
+
+	err := Encrypt(writer, reader)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCrypterNotInitialized)
+}
+
 func Test_Decrypt(t *testing.T) {
 	crypter = &base64Crypter{}
 
@@ -90,4 +106,20 @@ func Test_Decrypt(t *testing.T) {
 	err := Decrypt(writer, reader)
 	require.NoError(t, err)
 	assert.Equal(t, plaintext, writer.String())
+}
+
+func Test_Decrypt_NotInitialized(t *testing.T) {
+	prev := crypter
+	t.Cleanup(func() {
+		crypter = prev
+	})
+
+	crypter = nil
+
+	reader := bytes.NewBufferString("SGVsbG8gV29ybGQ=")
+	writer := new(bytes.Buffer)
+
+	err := Decrypt(writer, reader)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCrypterNotInitialized)
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,7 @@
+package sqlcrypter
+
+import "errors"
+
+// ErrCrypterNotInitialized indicates that Init() has not been called
+// with a valid Crypterer before Encrypt()/Decrypt() usage.
+var ErrCrypterNotInitialized = errors.New("sqlcrypter: crypter is not initialized")


### PR DESCRIPTION
A runtime panic can occur if `Init()` is omitted or called with nil.